### PR TITLE
Get latest code id

### DIFF
--- a/juno/deploy_minter.sh
+++ b/juno/deploy_minter.sh
@@ -17,7 +17,7 @@ junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/minter_metadata_onchain.wasm 
 
 
 
-CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[01].code_id')
+CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[0].code_id')
 CURRENT_TIME=$(($(date +%s)+10))
 # Load INIT payload
 MINT_INIT='{

--- a/juno/deploy_minter.sh
+++ b/juno/deploy_minter.sh
@@ -17,7 +17,7 @@ junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/minter_metadata_onchain.wasm 
 
 
 
-CODE_ID=$(junod query wasm list-code --output json | jq -r '.code_infos[-1].code_id')
+CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[01].code_id')
 CURRENT_TIME=$(($(date +%s)+10))
 # Load INIT payload
 MINT_INIT='{
@@ -812,10 +812,10 @@ cd "$CURRENT_DIR" || exit
 echo "Deploying pg721 metadata onchain contract..."
 junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/pg721_metadata_onchain.wasm --from $KEY --gas auto --gas-adjustment 1.15 --chain-id $CHAINID -y -b block
 
-NFT_CODE_ID=$(junod query wasm list-code --output json | jq -r '.code_infos[-1].code_id')
+NFT_CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[0].code_id')
 sed -i "s/^new_nft_code_id=.*/new_nft_code_id=$NFT_CODE_ID/" .env
 
-migrate_msg='{"minter":"'"$MINT_CONTRACT"'"}' 
+migrate_msg='{"minter":"'"$MINT_CONTRACT"'"}'
 echo "Change minter to minting contract...."
 junod tx wasm migrate "$new_nft_address" "$NFT_CODE_ID" "$migrate_msg" --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block
 

--- a/juno/deploy_pg721.sh
+++ b/juno/deploy_pg721.sh
@@ -15,7 +15,7 @@ junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/pg721_metadata_onchain.wasm -
 
 
 
-NFT_CODE_ID=$(junod query wasm list-code --output json | jq -r '.code_infos[-1].code_id')
+NFT_CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[0].code_id')
 sed -i "s/^new_nft_code_id=.*/new_nft_code_id=$NFT_CODE_ID/" .env
 
 # Load INIT payload

--- a/juno/update_marketplace.sh
+++ b/juno/update_marketplace.sh
@@ -8,7 +8,7 @@ cd "$CURRENT_DIR" || exit
 echo "$name: Deploying new marketplace legacy contract..."
 junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/marketplace_legacy.wasm --from $KEY --gas auto --gas-adjustment 1.15 --chain-id $CHAINID -y -b block
 
-MP_CODE_ID=$(junod query wasm list-code --output json | jq -r '.code_infos[-1].code_id')
+MP_CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[0].code_id')
 
 echo "$name: Migrating marketplace legacy contract for decommission..."
-junod tx wasm migrate "$marketplace_address" "$MP_CODE_ID" '{}' --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block 
+junod tx wasm migrate "$marketplace_address" "$MP_CODE_ID" '{}' --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block

--- a/juno/update_minter_contract.sh
+++ b/juno/update_minter_contract.sh
@@ -9,7 +9,7 @@ cd "$CURRENT_DIR" || exit
 echo "$name: Deploying new minter metadata onchain contract..."
 junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/minter_metadata_onchain.wasm --from $KEY --gas auto --gas-adjustment 1.15 --chain-id $CHAINID -y -b block
 
-MINT_CODE_ID=$(junod query wasm list-code --output json | jq -r '.code_infos[-1].code_id')
+MINT_CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[0].code_id')
 
 echo "$name: Migrating minter metadata onchain contract for decommission..."
-junod tx wasm migrate "$minter_address" "$MINT_CODE_ID" '{}' --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block 
+junod tx wasm migrate "$minter_address" "$MINT_CODE_ID" '{}' --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block

--- a/juno/update_nft_contract.sh
+++ b/juno/update_nft_contract.sh
@@ -8,7 +8,7 @@ cd "$CURRENT_DIR" || exit
 echo "$name: Deploying new pg721 metadata onchain contract..."
 junod tx wasm store "$PATH_TO_CONTRACTS"/artifacts/pg721_metadata_onchain.wasm --from $KEY --gas auto --gas-adjustment 1.15 --chain-id $CHAINID -y -b block
 
-NFT_CODE_ID=$(junod query wasm list-code --output json | jq -r '.code_infos[-1].code_id')
+NFT_CODE_ID=$(junod query wasm list-code --reverse --output json | jq -r '.code_infos[0].code_id')
 
 echo "$name: Migrating pg721 metadata onchain contract for decommission..."
-junod tx wasm migrate "$nft_address" "$NFT_CODE_ID" '{"minter":""}' --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block 
+junod tx wasm migrate "$nft_address" "$NFT_CODE_ID" '{"minter":""}' --from $KEY --chain-id $CHAINID --gas auto --gas-adjustment 1.15 -y -b block


### PR DESCRIPTION
`junod query wasm list-code` returns a paginated list; request the list in the reversed order so the latest contract deployment is at `index: 0`